### PR TITLE
feat: Add debounce to play next/prev buttons (#40)

### DIFF
--- a/components/player/controls.tsx
+++ b/components/player/controls.tsx
@@ -1,7 +1,9 @@
 import ProgressBar from "@/components/player/progress-bar";
 import { cn } from "@/lib/utils";
+import { debounce } from "@/lib/utils/debounce";
 import { usePlayerStore } from "@/lib/zustand/store";
 import NumberFlow from "@number-flow/react";
+import React from "react";
 import { BsFillSkipStartFill, BsFillSkipEndFill } from "react-icons/bs";
 import { FaStop, FaPlay } from "react-icons/fa";
 import { LuDot, LuRepeat1 } from "react-icons/lu";
@@ -19,6 +21,7 @@ export default function Controls({
     </div>
   );
 }
+
 function TimeDisplay({ duration }: { duration: number }) {
   const minutes = Math.floor(duration / 60);
   const seconds = Math.floor(duration % 60);
@@ -89,6 +92,16 @@ function Buttons({ handlePlayStop }: { handlePlayStop: () => void }) {
     isPlaying,
   } = usePlayerStore((state) => state);
 
+  // Debounce playNext and playPrevious with 300ms delay
+  const debouncedPlayNext = React.useMemo(
+    () => debounce(playNext, 300),
+    [playNext]
+  );
+  const debouncedPlayPrevious = React.useMemo(
+    () => debounce(playPrevious, 300),
+    [playPrevious]
+  );
+
   return (
     <div className="w-50 flex sm:gap-4 md:gap-6">
       <button
@@ -105,7 +118,7 @@ function Buttons({ handlePlayStop }: { handlePlayStop: () => void }) {
       </button>
       <button
         className="text-neutral-400 hover:text-neutral-50 transition active:scale-90 active:text-neutral-400"
-        onClick={playPrevious}
+        onClick={debouncedPlayPrevious}
       >
         <BsFillSkipStartFill size={25} />
       </button>
@@ -121,7 +134,7 @@ function Buttons({ handlePlayStop }: { handlePlayStop: () => void }) {
       </button>
       <button
         className="text-neutral-400 hover:text-neutral-50 transition active:scale-90 active:text-neutral-400"
-        onClick={playNext}
+        onClick={debouncedPlayNext}
       >
         <BsFillSkipEndFill size={25} />
       </button>

--- a/lib/utils/debounce.ts
+++ b/lib/utils/debounce.ts
@@ -1,0 +1,17 @@
+export function debounce<T extends (...args: any[]) => any>(
+  func: T,
+  wait: number
+): (...args: Parameters<T>) => void {
+  let timeoutId: NodeJS.Timeout | null = null;
+
+  return function(this: ThisParameterType<T>, ...args: Parameters<T>) {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    timeoutId = setTimeout(() => {
+      func.apply(this, args);
+      timeoutId = null;
+    }, wait);
+  };
+}


### PR DESCRIPTION
- Add debounce utility function with proper TypeScript typing
- Apply 300ms debounce to playNext and playPrevious buttons
- Prevent rapid-fire clicks from triggering multiple track changes
- Maintain proper this context and type safety